### PR TITLE
Update filetype filter

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+** 8/12/2021 **
+Bug Fixes
+---------
+- Changed filebrowser filter syntax for loading new CT scans. *.nii.gz appeared to break things for newer macOS (10.15+) systems.
+
 ** 6/1/18 **
 Bug Fixes
 ---------

--- a/view/pyloc.py
+++ b/view/pyloc.py
@@ -132,7 +132,7 @@ class PylocControl(object):
         Callback for "Load Scan" button. See :load_ct:
         :return:
         """
-        file_ = QtGui.QFileDialog().getOpenFileName(None, 'Select Scan', '.', '(*.img *.nii.gz *.nii)')
+        file_ = QtGui.QFileDialog().getOpenFileName(None, 'Select Scan', '.', '(*)')
         if file_:
             self.load_ct(filename=file_)
             self.view.task_bar.define_leads_button.setEnabled(True)

--- a/view/pyloc.py
+++ b/view/pyloc.py
@@ -132,7 +132,7 @@ class PylocControl(object):
         Callback for "Load Scan" button. See :load_ct:
         :return:
         """
-        file_ = QtGui.QFileDialog().getOpenFileName(None, 'Select Scan', '.', '(*.img *.nii.gz)')
+        file_ = QtGui.QFileDialog().getOpenFileName(None, 'Select Scan', '.', '(*.img *.nii.gz *.nii)')
         if file_:
             self.load_ct(filename=file_)
             self.view.task_bar.define_leads_button.setEnabled(True)

--- a/view/pyloc.py
+++ b/view/pyloc.py
@@ -132,7 +132,7 @@ class PylocControl(object):
         Callback for "Load Scan" button. See :load_ct:
         :return:
         """
-        file_ = QtGui.QFileDialog().getOpenFileName(None, 'Select Scan', '.', '(*.img; *.nii.gz)')
+        file_ = QtGui.QFileDialog().getOpenFileName(None, 'Select Scan', '.', '(*.img *.nii.gz)')
         if file_:
             self.load_ct(filename=file_)
             self.view.task_bar.define_leads_button.setEnabled(True)


### PR DESCRIPTION
Load Scan was breaking when trying to load files (files were not clickable). 

I updated the getOpenFilename filter string and tested it on a Mac OS >= 10.15. The error likely occurred from changes in pyface.qt: QtGui